### PR TITLE
Add app_id_prefix as input

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,6 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 app:
   envs:
   # define these in your .bitrise.secrets.yml
+  - APP_ID_PREFIX: $APP_ID_PREFIX
   - ITUNES_CONNECT_TEAM_ID: $ITUNES_CONNECT_TEAM_ID
   - DISTRIBUTION_TYPE: $DISTRIBUTION_TYPE
   - BITRISE_IPA_PATH: $BITRISE_IPA_PATH

--- a/step.rb
+++ b/step.rb
@@ -12,8 +12,11 @@ begin
   team_id = ENV['itunes_connect_team_id']
   team_id = nil if ENV['itunes_connect_team_id'].to_s.eql?('')
 
+  app_id_prefix = ENV['app_id_prefix']
+  app_id_prefix = nil if ENV['app_id_prefix'].to_s.eql?('')
+
   resigner = Resigner.new
-  resigner.resign(distribution_type, ipa_path, team_id)
+  resigner.resign(distribution_type, ipa_path, team_id, app_id_prefix)
 rescue => ex
   puts "\e[31mError: #{ex}\e[0"
   puts "\e[31mFailed to resign ipa\e[0m"

--- a/step.yml
+++ b/step.yml
@@ -23,6 +23,11 @@ inputs:
       title: "iTunes Connect Team ID"
       description: |
         Specify your team ID for signing
+  - app_id_prefix:
+    opts:
+      title: "iTunes Connect Application ID Prefix"
+      description: |
+        Specify your application ID prefix for signing. This is for managing legacy app IDs created before June 2011.
   - ipa_path: $BITRISE_IPA_PATH
     opts:
       title: "IPA path"


### PR DESCRIPTION
One of our iOS apps has a legacy app ID prefix that is not the same as the team ID. This can be true of apps created prior to June 2011. You can see more details here, specifically in the Overview section: https://developer.apple.com/library/ios/technotes/tn2311/_index.html

This change optionally lets the developer specify an app ID prefix should it differ from the team ID.
